### PR TITLE
Fix SLSA provenance

### DIFF
--- a/.github/workflows/slsa.yml
+++ b/.github/workflows/slsa.yml
@@ -61,9 +61,9 @@ jobs:
 
   provenance:
     needs: [subjects]
-    # This will fail, because generator_generic_slsa3 demands using version pinning, instead of hash pinning.
-    # Instead, use the workflow from the 'slsa' branch.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
+    # This is a fix, because generator_generic_slsa3 demands using version pinning, instead of hash pinning.
+    # Do not merge this into the default branch.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0 # f7dd8c54c2067bafc12ca7a55595d5ee9b75204a
 
     permissions:
       actions: read


### PR DESCRIPTION
This PR exists just to silence GitHub from suggesting to create one. This PR will be closed (without merge) immediately.

The 'slsa' branch exists just to fix the fact that we want hash-pinning of actions, but generator_generic_slsa3 only works with version pinning.